### PR TITLE
#157925184: users reset password

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "nyc mocha  --reporter progress --reporter progress --require babel-core/register \"server/test/**/**.test.js\" --exit || true",
     "coverage": "nyc --reporter=lcov --reporter=text-lcov npm test",
     "build": "babel ./server/ -d build --copy-files -s",
-    "custome-migrate": "npm run start-file server/database/initScript.js",
+    "drop-tables": "npm run start-file server/database/dropScript.js",
     "temp": "babel-node minimist.js -production true",
     "start-test": " babel-node  server/database/initTestConfig.js && npm run start",
     "start-prod": " babel-node  server/database/initProduction.js "

--- a/server/controller/Controller.js
+++ b/server/controller/Controller.js
@@ -1,0 +1,12 @@
+export default class Controller {
+  static verifyUser(req, resp, userType) {
+    if (!req.authData[userType]) {
+      resp.status(403).json({
+        success: false,
+        message: `Only ${userType}(s) can make a request`,
+      });
+      return false;
+    }
+    return true;
+  }
+}

--- a/server/controller/RequestController.js
+++ b/server/controller/RequestController.js
@@ -1,6 +1,6 @@
 import requestService from '../services/requestService';
 import RequestValidator from '../validators/RequestValidator';
-
+import Controller from './Controller';
 
 function getRequest(body) {
   const request = {
@@ -20,21 +20,12 @@ function getStatus(status) {
   return false;
 }
 
-function verifyUser(req, resp, userType) {
-  if (!req.authData[userType]) {
-    resp.status(403).json({
-      success: false,
-      message: `Only ${userType}(s) can make a request`,
-    });
-    return false;
-  }
-  return true;
-}
-export default class RequestController {
+
+export default class RequestController extends Controller {
   static modify(req, resp) {
     const { request, validationResult } = getRequest(req.body);
     const { params: { id } } = req;
-    if (!verifyUser(req, resp, 'client')) return;
+    if (!RequestController.verifyUser(req, resp, 'client')) return;
     if (validationResult.valid) {
       const user = req.authData.client;
       requestService.modify(user.username, request, id, (result) => {
@@ -46,14 +37,14 @@ export default class RequestController {
   }
 
   static getStats(req, resp) {
-    if (!verifyUser(req, resp, 'engineer')) return;
+    if (!RequestController.verifyUser(req, resp, 'engineer')) return;
     requestService.getStatistics((result) => {
       resp.status(result.statusCode).json(result.respObj);
     });
   }
   static create(req, resp) {
     const { request, validationResult } = getRequest(req.body, req.authData.client.username);
-    if (!verifyUser(req, resp, 'client')) return;
+    if (!RequestController.verifyUser(req, resp, 'client')) return;
     if (validationResult.valid) {
       request.clientUsername = req.authData.client.username;
       requestService.makeRequest(request, (result) => {
@@ -66,14 +57,14 @@ export default class RequestController {
 
 
   static getAllClientRequests(req, resp) {
-    if (!verifyUser(req, resp, 'client')) return;
+    if (!RequestController.verifyUser(req, resp, 'client')) return;
     requestService.getByUsername(req.authData.client.username, (result) => {
       resp.status(result.statusCode).json(result.respObj);
     });
   }
 
   static getAll(req, resp) {
-    if (!verifyUser(req, resp, 'engineer')) return;
+    if (!RequestController.verifyUser(req, resp, 'engineer')) return;
     requestService.getAll((result) => {
       resp.status(result.statusCode).json(result.respObj);
     });
@@ -81,7 +72,7 @@ export default class RequestController {
 
 
   static getById(req, resp) {
-    if (!verifyUser(req, resp, 'client')) return;
+    if (!RequestController.verifyUser(req, resp, 'client')) return;
     const { params: { id } } = req;
     requestService.getById(req.authData.client.username, id, (result) => {
       resp.status(result.statusCode).json(result.respObj);
@@ -89,7 +80,7 @@ export default class RequestController {
   }
   static updateStatus(req, resp) {
     const { params: { status, id } } = req;
-    if (!verifyUser(req, resp, 'engineer')) return;
+    if (!RequestController.verifyUser(req, resp, 'engineer')) return;
     const statusValue = getStatus(status);
 
     if (statusValue) {

--- a/server/controller/UserController.js
+++ b/server/controller/UserController.js
@@ -1,7 +1,9 @@
 import userService from '../services/userService';
-import UserValidator from '../validators/UserValidator';
+import SignUpValidator from '../validators/SignUpValidator';
 import LoginValidator from '../validators/LoginValidator';
 import authenticator from '../helpers/authenticator';
+import Controller from './Controller';
+import UserValidator from '../validators/UserValidator';
 
 function getUser(body) {
   const {
@@ -11,27 +13,14 @@ function getUser(body) {
     email, username, password, userType,
   };
 
-  const validationResult = new UserValidator(user).validate();
+  const validationResult = new SignUpValidator(user).validate();
   return { user, validationResult };
 }
 
-export default class UserController {
+
+export default class UserController extends Controller {
   static signup(req, resp) {
-    const { validationResult, user } = getUser(req.body);
-    if (validationResult.valid) {
-      userService.createUser(user, (result) => {
-        if (result.respObj.data) {
-          UserController.createToken(result.respObj.data, 'client', (err, token) => {
-            result.respObj.data.token = token;// eslint-disable-line no-param-reassign
-            resp.status(result.statusCode).json(result.respObj);
-          });
-        } else {
-          resp.status(result.statusCode).json(result.respObj);
-        }
-      });
-    } else {
-      resp.status(400).json(UserValidator.handleBadData(validationResult));
-    }
+    UserController.createUserHelper(req, resp);
   }
 
 
@@ -41,12 +30,11 @@ export default class UserController {
     };
     authenticator.createToken(payload, '3days', callback);
   }
+
   static login(req, resp) {
     const { username, password, userType } = req.body;
     const user = { username, password, userType };
     const validationResult = new LoginValidator(user).validate();
-
-
     if (validationResult.valid) {
       userService.getByCredentials(username, password, userType, (result) => {
         const { respObj } = result;
@@ -60,7 +48,78 @@ export default class UserController {
         }
       });
     } else {
-      resp.status(400).json(UserValidator.handleBadData(validationResult));
+      resp.status(400).json(LoginValidator.handleBadData(validationResult));
+    }
+  }
+
+  static createUserHelper(req, resp) {
+    const { validationResult, user } = getUser(req.body);
+    if (validationResult.valid) {
+      userService.createUser(user, (result) => {
+        if (result.respObj.data) {
+          UserController.createToken(result.respObj.data, 'client', (err, token) => {
+            result.respObj.data.token = token;// eslint-disable-line no-param-reassign
+            resp.status(result.statusCode).json(result.respObj);
+          });
+        } else {
+          resp.status(result.statusCode).json(result.respObj);
+        }
+      });
+    } else {
+      resp.status(400).json(SignUpValidator.handleBadData(validationResult));
+    }
+  }
+  static reset(req, resp) {
+    const { body: { email, userType } } = req;
+    const validator = new UserValidator({ email, userType }, 'email', 'userType');
+    const validationResult = validator.validate();
+
+    if (validationResult.valid) {
+      userService.emailExists(email, userType, (exists) => {
+        if (exists) {
+          UserController.createToken(email, userType, (err, token) => {
+            if (err) {
+              resp.status(500).json({
+                success: false,
+                message: 'An error occured while processing your request',
+              });
+            } else {
+              resp.status(201).json({
+                success: true,
+                data: { token },
+                message: 'Use this token to reset password of the specified email',
+              });
+            }
+          }, '');
+        } else {
+          resp.status(404).json({
+            success: false,
+            message: 'The email you specified does not exists',
+          });
+        }
+      });
+    } else {
+      resp.status(400).json(SignUpValidator.handleBadData(validationResult));
+    }
+  }
+
+  static acceptReset(req, resp) {
+    const { body: { username, password }, authData } = req;
+
+    const userType = authData.client ? 'client' : 'engineer';
+    const updateUser = { username, password };
+    updateUser.email = authData[userType];
+    console.log(authData, 'authData');
+    updateUser.userType = userType;
+    const validationResult = new LoginValidator(updateUser).validate();
+    if (validationResult.valid) {
+      userService.updateUser(updateUser, userType, (response) => {
+        resp.status(response.statusCode)
+          .json(response.respObj);
+      });
+    } else {
+      resp.status(400).json(LoginValidator.handleBadData(validationResult));
     }
   }
 }
+

--- a/server/database/dropScript.js
+++ b/server/database/dropScript.js
@@ -2,22 +2,14 @@ import clientInitializer from './intializers/clientInitializer';
 import engineerInitializer from './intializers/engineerInitializer';
 import requestInitializer from './intializers/requestInitializer';
 import DatabaseManager from './databaseManager';
-import Seeder from '../database/seeders/Seeder';
 
 if (process.env.NODE_ENV === 'production') {
   DatabaseManager.initProductionConfig();
 } else {
   DatabaseManager.initTestConfig();
 }
-export default function init() {
-  if (process.env.NODE_ENV !== 'production') {
-    requestInitializer.drop();
-    clientInitializer.drop();
-    engineerInitializer.drop();
-  }
-  clientInitializer.create();
-  engineerInitializer.create();
-  requestInitializer.create();
-  Seeder.seedEngineer();
-  DatabaseManager.setPoolMaxSize(4);
-}
+
+requestInitializer.drop();
+clientInitializer.drop();
+engineerInitializer.drop();
+

--- a/server/database/intializers/clientInitializer.js
+++ b/server/database/intializers/clientInitializer.js
@@ -1,11 +1,12 @@
 import Initializer from './Initializer';
 
 const createSql =
-`CREATE TABLE "Clients"
+`CREATE TABLE IF NOT EXISTS "Clients"
 (
     username character varying(100),
     password character varying(10000),
     email character varying(255),
+    CONSTRAINT clientuniqueMail UNIQUE (email),
     PRIMARY KEY (username)
 );
 

--- a/server/database/intializers/engineerInitializer.js
+++ b/server/database/intializers/engineerInitializer.js
@@ -1,11 +1,12 @@
 import Initializer from './Initializer';
 
 const createSql =
-`CREATE TABLE "Engineers"
+`CREATE TABLE IF NOT EXISTS "Engineers"
 (
     username character varying(100),
     password character varying(10000),
     email character varying(255),
+    CONSTRAINT uniqueMail UNIQUE (email),
     accessType character varying(100),
     PRIMARY KEY (username)
 );

--- a/server/database/intializers/requestInitializer.js
+++ b/server/database/intializers/requestInitializer.js
@@ -1,7 +1,7 @@
 import Initializer from './Initializer';
 
 const createSql =
-`CREATE TABLE "Requests"
+`CREATE TABLE IF NOT EXISTS "Requests"
 (
     id SERIAL,
     title character varying(100),

--- a/server/database/mappers/UserMapper.js
+++ b/server/database/mappers/UserMapper.js
@@ -33,56 +33,28 @@ export default class UserMapper extends TableMapper {
     this.tableName = tableName;
   }
 
-
-  /**
-     *This method uses this UserMapper's new user to run an sql statement that
-     updates the existingUser's password
-     * @param {function} callback
-     * @param {function} errorHandler
-     */
-  updatePassword(callback, errorHandler) {
-    const { newUser, existingUser } = this;
-    const sql = `UPDATE "${this.tableName}" SET password = ($1)
-        WHERE password = ($2) AND username = ($3)`;
-    const values = [newUser.password, existingUser.password, existingUser.username];
-    UserMapper.executeUpdateHelper(sql, values, callback, errorHandler);
-  }
-  /**
-     *Uses this UserMapper's newUser object to run an sql statement that
-     updates the existingUser's username and password
-     * @param {function} callback
-     * @param {function} errorHandler
-     */
-  updateUsernameAndPassword(callback, errorHandler) {
-    const { newUser, existingUser } = this;
-    const sql = `UPDATE "${this.tableName}" 
-      SET username = $1, password = $2
-      WHERE password = $4 AND username = $5`;
-    const values = [
-      existingUser.username, existingUser.password,
-      newUser.username, newUser.password];
-    UserMapper.executeUpdateHelper(sql, values, callback, errorHandler);
-  }
-
-  /**
-     *Uses this UserMapper's newUser object to run an sql statement that
-     updates the existingUser's email address
-     * @param {function} callback
-     * @param {function} errorHandler
-     */
-  updateEmail(callback, errorHandler) {
-    const { newUser, existingUser } = this;
-    const sql = `UPDATE "${this.tableName}" SET email = ($1)
-      WHERE password = ($4) AND username = ($5)`;
-    const values = [newUser.email, existingUser.password, existingUser.username];
-    UserMapper.executeUpdateHelper(sql, values, callback, errorHandler);
-  }
-
   static loginQuery(username, password, tableName, callback, errorHandler) {
     const sql = `SELECT username, email FROM "${tableName}" 
                     WHERE username = $1 AND password = $2`;
 
     UserMapper.executeUpdateHelper(sql, [username, password], callback, errorHandler);
+  }
+
+
+  static findMail(email, tableName, callback, errorHandler) {
+    const sql = `SELECT username, email FROM "${tableName}" 
+            WHERE email = $1; `;
+
+    UserMapper.executeUpdateHelper(sql, [email], callback, errorHandler);
+  }
+
+  static updateCredentials(user, tableName, callback, errorHandler) {
+    const sql =
+    `UPDATE "${tableName}" 
+        SET username = $1, password = $2
+        WHERE email = $3 RETURNING username, email;`;
+    const values = [user.username, user.password, user.email];
+    UserMapper.executeUpdateHelper(sql, values, callback, errorHandler);
   }
 }
 

--- a/server/database/seeders/Seeder.js
+++ b/server/database/seeders/Seeder.js
@@ -26,8 +26,13 @@ export default class Seeder {
 
   static seedEngineer() {
     const passwordHash = PasswordHasher.hash('super123456');
-    DatabaseManager.executeStream(`INSERT INTO "Engineers"(username, password, email, accessType)
-    VALUES('superEngineer', $1, 'super@email.com', 'super');`, () => {
+    DatabaseManager.executeStream(`
+      INSERT INTO "Engineers"(username, password, email, accessType)
+        SELECT 'superEngineer', $1, 'super@email.com', 'super'
+          WHERE 0 =
+            (
+              SELECT COUNT(*) FROM "Engineers"
+            );`, () => {
       console.log('Successfully seeded the engineer table');
     }, (err) => {
       console.log(err);

--- a/server/routes/v1/authRouter.js
+++ b/server/routes/v1/authRouter.js
@@ -1,10 +1,12 @@
 import { Router } from 'express';
-
+import authenticator from '../../helpers/authenticator';
 import UserController from '../../controller/UserController';
 
 const authRouter = Router();
 
 authRouter.post('/login', UserController.login);
 authRouter.post('/signup', UserController.signup);
+authRouter.post('/reset', UserController.reset);
+authRouter.put('/reset', authenticator.verifyToken, UserController.acceptReset);
 
 export default authRouter;

--- a/server/test/routes/userRoute.test.js
+++ b/server/test/routes/userRoute.test.js
@@ -8,12 +8,25 @@ import initScript from '../../database/initScript';
 import Seeder from '../../database/seeders/Seeder';
 
 const request = supertest(app);
+
+const clientEmail = 'email@email.com';
+const clientInitResetObj = {
+  email: clientEmail,
+  userType: 'client',
+};
 const validClient = {
   username: 'username',
   password: 'password0',
-  email: 'email@email.com',
+  email: clientEmail,
   userType: 'client',
 };
+
+const newClient = {
+  username: 'newClientUsername',
+  password: 'newPassword123456',
+  userType: 'client',
+};
+
 const invalidObj = {
   username: 'rr',
   password: 'a',
@@ -25,8 +38,9 @@ describe('User Routes', () => {
   describe('POST routes', () => {
     const SIGNUP_ROUTE = '/api/v1/auth/signup';
     describe(SIGNUP_ROUTE, () => {
-      beforeEach(() => {
+      beforeEach((done) => {
         initScript();
+        done();
       });
 
       describe('if request is valid', () => {
@@ -232,6 +246,361 @@ describe('User Routes', () => {
                 expect(resp.body).property('invalidData').to.be.a('array');
                 done();
               });
+          });
+        });
+      });
+    });
+
+    const RESET_ROUTE = '/api/v1/auth/reset';
+
+    describe(`POST ${RESET_ROUTE}`, () => {
+      describe('if request is valid', () => {
+        describe('response status code', () => {
+          it('should return status 201', (done) => {
+            request
+              .post(RESET_ROUTE)
+              .send(clientInitResetObj)
+              .set('Accept', 'application/json')
+              .set('Content-Type', 'application/x-www-form-urlencoded')
+              .expect(201, done);
+          });
+        });
+        describe('response body', () => {
+          it('should have a success property that is true', (done) => {
+            request
+              .post(RESET_ROUTE)
+              .set('Accept', 'application/json')
+              .set('Content-Type', 'application/x-www-form-urlencoded')
+              .send(clientInitResetObj)
+              .end((error, resp) => {
+                expect(resp.body).property('success').to.be.true;
+                done();
+              });
+          });
+
+          it('should have a data property that is an object with property token', (done) => {
+            request
+              .post(RESET_ROUTE)
+              .send(clientInitResetObj)
+              .set('Accept', 'application/json')
+              .set('Content-Type', 'application/x-www-form-urlencoded')
+              .end((error, resp) => {
+                expect(resp.body).property('data').property('token');
+                done();
+              });
+          });
+
+          it('should have a message property ', (done) => {
+            request
+              .post(RESET_ROUTE)
+              .send(clientInitResetObj)
+              .set('Accept', 'application/json')
+              .set('Content-Type', 'application/x-www-form-urlencoded')
+              .end((error, resp) => {
+                expect(resp.body).property('message');
+                done();
+              });
+          });
+        });
+      });
+
+      describe('if some fields are missing in the requests', () => {
+        describe('response status code', () => {
+          it('should return status 400', (done) => {
+            request
+              .post(RESET_ROUTE)
+              .send({})
+              .set('Accept', 'application/json')
+              .set('Content-Type', 'application/x-www-form-urlencoded')
+              .expect(400, done);
+          });
+        });
+
+        describe('response body', () => {
+          it('should have a success property that is false and a missingData property that is a array', (done) => {
+            request
+              .post(RESET_ROUTE)
+              .set('Accept', 'application/json')
+              .set('Content-Type', 'application/x-www-form-urlencoded')
+              .send({})
+              .end((error, resp) => {
+                expect(resp.body).property('success').to.be.false;
+                expect(resp.body).property('missingData').to.be.a('array');
+                done();
+              });
+          });
+        });
+      });
+
+      describe('if the email in the request is invalid ', () => {
+        const invalidResetObj = {
+          email: 'chi.com',
+        };
+        describe('response status code', () => {
+          it('should return status 400', (done) => {
+            request
+              .post(RESET_ROUTE)
+              .send(invalidResetObj)
+              .set('Accept', 'application/json')
+              .set('Content-Type', 'application/x-www-form-urlencoded')
+              .expect(400, done);
+          });
+        });
+
+        describe('response body', () => {
+          it('should have a success property that is false ', (done) => {
+            request
+              .post(RESET_ROUTE)
+              .set('Accept', 'application/json')
+              .set('Content-Type', 'application/x-www-form-urlencoded')
+              .send(invalidResetObj)
+              .end((error, resp) => {
+                expect(resp.body).property('success').to.be.false;
+                done();
+              });
+          });
+        });
+      });
+    });
+    describe(RESET_ROUTE, () => {
+      let resetToken = '';
+      describe(`PUT ${RESET_ROUTE}`, () => {
+        before((done) => {
+          request
+            .post(RESET_ROUTE)
+            .send(clientInitResetObj)
+            .set('Accept', 'application/json')
+            .set('Content-Type', 'application/x-www-form-urlencoded')
+            .end((err, resp) => {
+              console.log(resetToken, 'resteToken');
+              resetToken = resp.body.data.token;
+
+              done();
+            });
+        });
+
+
+        describe('if the request is valid', () => {
+          describe('status code', () => {
+            it('should equal 201 Created', (done) => {
+              request
+                .put(RESET_ROUTE)
+                .set('x-access-token', resetToken)
+                .send(newClient)
+                .set('Accept', 'application/json')
+                .set('Content-Type', 'application/x-www-form-urlencoded')
+                .expect(201, done);
+            });
+          });
+
+          describe('response body', () => {
+            it('should have a success property that is true', (done) => {
+              request
+                .put(RESET_ROUTE)
+                .set('x-access-token', resetToken)
+                .set('Accept', 'application/json')
+                .set('Content-Type', 'application/x-www-form-urlencoded')
+                .send(newClient)
+                .end((err, resp) => {
+                  console.log(resp.body, 'badBody');
+                  expect(resp.body).property('success')
+                    .to.be.true;
+                  done();
+                });
+            });
+
+            it('should have a data property with properties email and password', (done) => {
+              request
+                .put(RESET_ROUTE)
+                .set('x-access-token', resetToken)
+                .set('Accept', 'application/json')
+                .set('Content-Type', 'application/x-www-form-urlencoded')
+                .send(newClient)
+                .end((err, resp) => {
+                  expect(resp.body)
+                    .property('data')
+                    .property('email');
+                  expect(resp.body)
+                    .property('data')
+                    .property('username');
+                  done();
+                });
+            });
+
+            describe('data property', () => {
+              it(`email must equal ${clientInitResetObj.email}`, (done) => {
+                request
+                  .put(RESET_ROUTE)
+                  .set('x-access-token', resetToken)
+                  .set('Accept', 'application/json')
+                  .set('Content-Type', 'application/x-www-form-urlencoded')
+                  .send(newClient)
+                  .end((err, resp) => {
+                    expect(resp.body)
+                      .property('data')
+                      .property('email')
+                      .to.equal(clientInitResetObj.email);
+                    done();
+                  });
+              });
+
+              it(`username must equal ${newClient.username}`, (done) => {
+                request
+                  .put(RESET_ROUTE)
+                  .set('x-access-token', resetToken)
+                  .set('Accept', 'application/json')
+                  .set('Content-Type', 'application/x-www-form-urlencoded')
+                  .send(newClient)
+                  .end((err, resp) => {
+                    expect(resp.body)
+                      .property('data')
+                      .property('username')
+                      .to.equal(newClient.username);
+                    done();
+                  });
+              });
+            });
+          });
+        });
+        describe('if the request is invalid', () => {
+          describe('if the token is invalid', () => {
+            describe('status code', (done) => {
+              it('should equal 403 Forbidden', () => {
+                request
+                  .put(RESET_ROUTE)
+                  .set('x-access-token', 'dsad')
+                  .set('Accept', 'application/json')
+                  .set('Content-Type', 'application/x-www-form-urlencoded')
+                  .expect(403, done);
+              });
+            });
+
+            describe('request body', () => {
+              it('should have a success property equal to false', (done) => {
+                request
+                  .put(RESET_ROUTE)
+                  .set('x-access-token', 'dsad')
+                  .set('Accept', 'application/json')
+                  .set('Content-Type', 'application/x-www-form-urlencoded')
+                  .end((err, resp) => {
+                    expect(resp.body).property('success').to.be.false;
+                    done();
+                  });
+              });
+              it('should have a message property ', (done) => {
+                request
+                  .put(RESET_ROUTE)
+                  .set('x-access-token', 'dsad')
+                  .set('Accept', 'application/json')
+                  .set('Content-Type', 'application/x-www-form-urlencoded')
+                  .end((err, resp) => {
+                    expect(resp.body).property('message');
+                    done();
+                  });
+              });
+            });
+          });
+
+
+          describe('if the object token is valid but some data is missing in request', () => {
+            describe('status code', () => {
+              it('should be equal to 400 Bad Request', (done) => {
+                request
+                  .put(RESET_ROUTE)
+                  .set('x-access-token', resetToken)
+                  .set('Accept', 'application/json')
+                  .set('Content-Type', 'application/x-www-form-urlencoded')
+                  .send({})
+                  .expect(400, done);
+              });
+            });
+            describe('response body', () => {
+              it('should have  an missingData proerty ', (done) => {
+                request
+                  .put(RESET_ROUTE)
+                  .set('x-access-token', resetToken)
+                  .set('Accept', 'application/json')
+                  .set('Content-Type', 'application/x-www-form-urlencoded')
+                  .send({})
+                  .end((err, resp) => {
+                    expect(resp.body).property('missingData')
+                      .to.be.an('array');
+                    done();
+                  });
+              });
+              it('should have success property equal to false', (done) => {
+                request
+                  .put(RESET_ROUTE)
+                  .set('x-access-token', resetToken)
+                  .set('Accept', 'application/json')
+                  .set('Content-Type', 'application/x-www-form-urlencoded')
+                  .send({})
+                  .end((err, resp) => {
+                    expect(resp.body).property('success').to.be.false;
+                    done();
+                  });
+              });
+
+              it('should have message property ', (done) => {
+                request
+                  .put(RESET_ROUTE)
+                  .set('x-access-token', resetToken)
+                  .set('Accept', 'application/json')
+                  .set('Content-Type', 'application/x-www-form-urlencoded')
+                  .send({})
+                  .end((err, resp) => {
+                    expect(resp.body).property('message');
+                    done();
+                  });
+              });
+            });
+          });
+
+          describe('if the object token is valid but the request body in invalid', () => {
+            describe('response body', () => {
+              it('should have success property equal to false', (done) => {
+                request
+                  .put(RESET_ROUTE)
+                  .set('x-access-token', resetToken)
+                  .set('Accept', 'application/json')
+                  .set('Content-Type', 'application/x-www-form-urlencoded')
+                  .send(invalidObj)
+                  .end((err, resp) => {
+                    expect(resp.body).property('success').to.be.false;
+                    done();
+                  });
+              });
+
+              it('should have message property ', (done) => {
+                request
+                  .put(RESET_ROUTE)
+                  .set('x-access-token', resetToken)
+                  .set('Accept', 'application/json')
+                  .set('Content-Type', 'application/x-www-form-urlencoded')
+                  .send(invalidObj)
+                  .end((err, resp) => {
+                    expect(resp.body).property('message');
+                    done();
+                  });
+              });
+
+              it('should have  an invalidData proerty that is an array of objects', (done) => {
+                request
+                  .put(RESET_ROUTE)
+                  .set('x-access-token', resetToken)
+                  .set('Accept', 'application/json')
+                  .set('Content-Type', 'application/x-www-form-urlencoded')
+                  .send(invalidObj)
+                  .end((err, resp) => {
+                    expect(resp.body).property('invalidData')
+                      .to.be.an('array');
+                    const arr = resp.body.invalidData;
+                    expect(arr.every(item => typeof item === 'object'))
+                      .to.be.true;
+                    done();
+                  });
+              });
+            });
           });
         });
       });

--- a/server/validators/LoginValidator.js
+++ b/server/validators/LoginValidator.js
@@ -1,36 +1,23 @@
-import ModelValidator from './ModelValidator';
+import UserValidator from './UserValidator';
 
 
-class LoginValidator extends ModelValidator {
+class LoginValidator extends UserValidator {
   constructor(model) {
-    super(model, {
-      password: {
-        message: 'must be at least 5 characters of any type',
-        pattern: /.{5,}/g,
-      },
-      userType: {
-        message: 'must be either "engineer" or "client"',
-        pattern: /client|engineer/i,
-      },
-      username: {
-        message: 'can contain letters or number but must begin with a letter',
-        pattern: /[a-z][a-z0-9]{3,}/g,
-      },
-    });
+    super(model, 'password', 'userType', 'username');
   }
 
-  validate() {
-    const {
-      model: {
-        password, userType, username,
-      },
-    } = this;
+  // validate() {
+  //   const {
+  //     model: {
+  //       password, userType, username,
+  //     },
+  //   } = this;
 
-    const testObj = {
-      password, userType, username,
-    };
-    return super.runValidation(testObj);
-  }
+  //   const testObj = {
+  //     password, userType, username,
+  //   };
+  //   return super.runValidation(testObj);
+  // }
 }
 
 export default LoginValidator;

--- a/server/validators/ModelValidator.js
+++ b/server/validators/ModelValidator.js
@@ -11,7 +11,6 @@ export default class ModelValidator {
     return this.requirements[key].pattern;
   }
 
-
   runValidation(testObj) {
     const invalidData = [];
     const missingData = [];

--- a/server/validators/SignUpValidator.js
+++ b/server/validators/SignUpValidator.js
@@ -1,0 +1,11 @@
+import UserValidator from './UserValidator';
+
+
+class SignUpValidator extends UserValidator {
+  constructor(model) {
+    super(model, 'username', 'password', 'email', 'userType');
+  }
+}
+
+export default SignUpValidator;
+

--- a/server/validators/UserValidator.js
+++ b/server/validators/UserValidator.js
@@ -2,8 +2,8 @@ import ModelValidator from './ModelValidator';
 
 
 class UserValidator extends ModelValidator {
-  constructor(model) {
-    super(model, {
+  constructor(model, ...requiredProperties) {
+    const userProperties = {
       password: {
         message: 'must be at least 5 characters of any type',
         pattern: /.{5,}/g,
@@ -20,20 +20,24 @@ class UserValidator extends ModelValidator {
         message: 'can contain letters or number but must begin with a letter',
         pattern: /[a-z][a-z0-9]{3,}/g,
       },
-    });
+    };
+    const requirements = {};
+    requiredProperties
+      .forEach((property) => {
+        requirements[property] = userProperties[property];
+      });
+    super(model, requirements);
+    this.requiredProperties = requiredProperties;
   }
 
   validate() {
-    const {
-      model: {
-        email, password, userType, username,
-      },
-    } = this;
+    const testProps = {};
+    this.requiredProperties
+      .forEach((elem) => {
+        testProps[elem] = this.model[elem];
+      });
 
-    const testObj = {
-      email, password, userType, username,
-    };
-    return super.runValidation(testObj);
+    return super.runValidation(testProps);
   }
 }
 


### PR DESCRIPTION
#### What does this PR do: 
- adds reset password feature to the app
- adds tests for the /auth/reset endpoint
- adds implementation for the /auth/reset endpoint
- ensures that all tests added pass

#### Description of Task to be completed?
- users should be able to reset their password when they forget it

#### Any background context you want to provide?
- all users (both clients and engineers) can do this
- all tokens must be passed to the header key x-access-token

#### How can this app be tested
- This app should be tested from the Heroku link https://fathomless-caverns-59927.herokuapp.com/
- First create an account as a client via POST /auth/signup endpoint
![signup](https://user-images.githubusercontent.com/38565349/40665560-d02261ec-635d-11e8-9392-2a4cd2320421.PNG)
- Then you obtain a reset token which expires in 10 mins via POST /auth/reset.  This prompts you for your email and returns a reset token which you would use for the next step
![reset begin token](https://user-images.githubusercontent.com/38565349/40665786-71c54b5e-635e-11e8-9e94-e68c5b77f0dd.PNG)
- This token should then be used to recover the password and username via PUT /auth/reset. This prompts you for a new username and new password
![complete password reset](https://user-images.githubusercontent.com/38565349/40669882-4325b932-6368-11e8-9e9e-d0044f04284d.PNG)
- You can run the previous command over and over before the token expires

####  Relevant PT Stories
- #157925184

#### What are the relevant Github Issues?
- none

#### Questions:
- none